### PR TITLE
Add iframe shortcode

### DIFF
--- a/layouts/shortcodes/iframe.html
+++ b/layouts/shortcodes/iframe.html
@@ -1,0 +1,2 @@
+<!-- layouts/shortcodes/iframe.html -->
+<iframe style="text-align:center" src="{{ .Get 0 }}" width="{{ .Get 1 }}" height="{{ .Get 2 }}"></iframe>


### PR DESCRIPTION
Add `iframe` shortcode to support embedded iframe in markdown.

This PR is related to #11 